### PR TITLE
Delete renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
Renovate generates too much noise. 

PRs aren't going through Travis, and certain modules that need to be updated together (react-testing-library & react main) done at separate PRs by Renovate increasing risk of failing builds.